### PR TITLE
AC Dipole Hotfix and Matrix implementation

### DIFF
--- a/pyhdtoolkit/cpymadtools/special.py
+++ b/pyhdtoolkit/cpymadtools/special.py
@@ -203,15 +203,16 @@ def install_ac_dipole(
     deltaqy: float,
     sigma_x: float,
     sigma_y: float,
+    beam: int = 1,
     geometric_emit: float = None,
     start_turn: int = 100,
     ramp_turns: int = 2000,
     top_turns: int = 6600,
 ) -> None:
     """
-    Installs an AC dipole for BEAM 1 ONLY.
-    This function assumes that you have already defined lhcb1, made a beam for it (BEAM command or
-    `make_lhc_beams` function) and matched to your desired working point.
+    Installs an AC dipole for (HL)LHC BEAM 1 OR 2 ONLY.
+    This function assumes that you have already defined lhcb1/lhcb2, made a beam for it (BEAM command or
+    `make_lhc_beams` function), matched to your desired working point and made a TWISS.
 
     Args:
         madx (cpymad.madx.Madx): an instanciated cpymad Madx object.
@@ -219,6 +220,7 @@ def install_ac_dipole(
         deltaqy (float): the deltaQy (vertical tune excitation) used by the AC dipole.
         sigma_x (float): the horizontal amplitude to drive the beam to, in bunch sigma.
         sigma_y (float): the vertical amplitude to drive the beam to, in bunch sigma.
+        beam (int): the LHC beam to install the AC Dipole into, either 1 or 2. Defaults to 1.
         geometric_emit (float): the geometric emittance that was used when defining the beam. If not
             provided, it is assumed that 'geometric_emit' is a defined global in MAD-X, and the value will
             be directly queried from the internal tables.
@@ -228,6 +230,10 @@ def install_ac_dipole(
             as in the LHC.
         top_turns (int): the number of turns to drive the beam for. Defaults to 6600 as in the LHC.
     """
+    logger.warning(
+        "This AC Dipole installation routine should be done after 'match', 'twiss' and 'makethin' "
+        "for the appropriate beam."
+    )
     if top_turns > 6600:
         logger.warning(
             f"Configuring the AC Dipole for {top_turns} of driving is fine for MAD-X but is "
@@ -251,22 +257,26 @@ def install_ac_dipole(
 
     logger.info(f"Installing AC Dipole to drive the tunes to Qx_D = {q1_dipole}  |  Qy_D = {q2_dipole}")
     madx.input(
-        f"MKACH.6L4.B1: hacdipole, l=0, freq:={q1_dipole}, lag=0, volt:=voltx, ramp1={ramp1}, "
+        f"MKACH.6L4.B{beam:d}: hacdipole, l=0, freq:={q1_dipole}, lag=0, volt:=voltx, ramp1={ramp1}, "
         f"ramp2={ramp2}, ramp3={ramp3}, ramp4={ramp4};"
     )
     madx.input(
-        f"MKACV.6L4.B1: vacdipole, l=0, freq:={q2_dipole}, lag=0, volt:=volty, ramp1={ramp1}, "
+        f"MKACV.6L4.B{beam:d}: vacdipole, l=0, freq:={q2_dipole}, lag=0, volt:=volty, ramp1={ramp1}, "
         f"ramp2={ramp2}, ramp3={ramp3}, ramp4={ramp4};"
     )
-    madx.command.seqedit(sequence="lhcb1")
+    madx.command.seqedit(sequence=f"lhcb{beam:d}")
     madx.command.flatten()
-    madx.command.install(element="MKACH.6L4.B1", at="0.0", from_="MKQA.6L4.B1")
-    madx.command.install(element="MKACV.6L4.B1", at="0.0", from_="MKQA.6L4.B1")
+    madx.command.install(  # same position as in model_creator macros
+        element=f"MKACH.6L4.B{beam:d}", at="1.583 / 2", from_=f"MKQA.6L4.B{beam:d}"
+    )
+    madx.command.install(  # same position as in model_creator macros
+        element=f"MKACV.6L4.B{beam:d}", at="1.583 / 2", from_=f"MKQA.6L4.B{beam:d}"
+    )
     madx.command.endedit()
 
     logger.trace("Querying BETX and BETY at AC Dipole location")
-    madx.input("betax_acd = table(twiss, MKQA.6L4.B1, betx);")
-    madx.input("betay_acd = table(twiss, MKQA.6L4.B1, bety);")
+    madx.input(f"betax_acd = table(twiss, MKQA.6L4.B{beam:d}, betx);")
+    madx.input(f"betay_acd = table(twiss, MKQA.6L4.B{beam:d}, bety);")
 
     betax_acd = madx.globals["betax_acd"]
     betay_acd = madx.globals["betay_acd"]
@@ -275,6 +285,12 @@ def install_ac_dipole(
     volty = sigma_y * np.sqrt(geometric_emit) * brho * np.abs(deltaqy) * 4 * np.pi / np.sqrt(betay_acd)
     madx.globals["voltx"] = voltx
     madx.globals["volty"] = volty
+
+    logger.warning(
+        f"Sequence LHCB{beam:d} is now re-used for changes to take effect. Beware that this will reset it "
+        "to its default state, remove errors etc."
+    )
+    madx.use(sequence=f"lhcb{beam:d}")
 
 
 def vary_independent_ir_quadrupoles(

--- a/pyhdtoolkit/cpymadtools/special.py
+++ b/pyhdtoolkit/cpymadtools/special.py
@@ -269,10 +269,10 @@ def install_ac_dipole(
     )
     madx.command.seqedit(sequence=f"lhcb{beam:d}")
     madx.command.flatten()
-    madx.command.install(  # same position as in model_creator macros
+    madx.command.install(  # same position as in model_creator macros to avoid negative drift
         element=f"MKACH.6L4.B{beam:d}", at="1.583 / 2", from_=f"MKQA.6L4.B{beam:d}"
     )
-    madx.command.install(  # same position as in model_creator macros
+    madx.command.install(  # same position as in model_creator macros to avoid negative drift
         element=f"MKACV.6L4.B{beam:d}", at="1.583 / 2", from_=f"MKQA.6L4.B{beam:d}"
     )
     madx.command.endedit()
@@ -329,10 +329,10 @@ def install_ac_dipole_matrix(madx: Madx, deltaqx: float, deltaqy: float, beam: i
 
     logger.trace("Calculating AC Dipole matrix terms")
     hacmap21 = (
-        2 * (np.cos(2 * np.pi * q1_dipole) - np.cos(2 * np.pi * q1)) / (betx_acd * np.sin(2 * np.pi * q1))
+        2 * (np.cos(2 * np.pi * q1_dipole) - np.cos(2 * np.pi * q1)) / (betax_acd * np.sin(2 * np.pi * q1))
     )
     vacmap43 = (
-        2 * (np.cos(2 * np.pi * q2_dipole) - np.cos(2 * np.pi * q2)) / (bety_acd * np.sin(2 * np.pi * q2))
+        2 * (np.cos(2 * np.pi * q2_dipole) - np.cos(2 * np.pi * q2)) / (betay_acd * np.sin(2 * np.pi * q2))
     )
     madx.input(f"hacmap: matrix, l=0, rm21={hacmap21};")
     madx.input(f"vacmap: matrix, l=0, rm43={vacmap43};")
@@ -340,12 +340,8 @@ def install_ac_dipole_matrix(madx: Madx, deltaqx: float, deltaqy: float, beam: i
     logger.info(f"Installing AC Dipole matrix with driven tunes of Qx_D = {q1_dipole}  |  Qy_D = {q2_dipole}")
     madx.command.seqedit(sequence=f"lhcb{beam:d}")
     madx.command.flatten()
-    madx.command.install(  # same position as in model_creator macros
-        element="hacmap", at="1.583 / 2", from_=f"MKQA.6L4.B{beam:d}"
-    )
-    madx.command.install(  # same position as in model_creator macros
-        element="vacmap", at="1.583 / 2", from_=f"MKQA.6L4.B{beam:d}"
-    )
+    madx.command.install(element="hacmap", at="1.583 / 2", from_=f"MKQA.6L4.B{beam:d}")  # no negative drift
+    madx.command.install(element="vacmap", at="1.583 / 2", from_=f"MKQA.6L4.B{beam:d}")  # no negative drift
     madx.command.endedit()
 
     logger.warning(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyhdtoolkit"
-version = "0.12.0"
+version = "0.13.0"
 description = "An all-in-one toolkit package to easy my Python work in my PhD."
 authors = ["Felix Soubelet <felix.soubelet@cern.ch>"]
 license = "MIT"

--- a/tests/test_cpymadtools.py
+++ b/tests/test_cpymadtools.py
@@ -55,6 +55,7 @@ from pyhdtoolkit.cpymadtools.special import (
     apply_lhc_rigidity_waist_shift_knob,
     deactivate_lhc_arc_sextupoles,
     install_ac_dipole,
+    install_ac_dipole_matrix,
     make_lhc_beams,
     make_lhc_thin,
     make_sixtrack_output,
@@ -830,6 +831,19 @@ class TestSpecial:
         assert madx.elements["MKACH.6L4.B1"].ramp4 == ramp4
         assert math.isclose(madx.elements["MKACH.6L4.B1"].at, 9846.0765, rel_tol=1e-2)
         assert math.isclose(madx.elements["MKACH.6L4.B1"].freq, 62.3, rel_tol=1e-2)
+
+    def test_install_ac_dipole_matrix(self, _matched_lhc_madx):
+        madx = _matched_lhc_madx
+        twiss_before = madx.twiss().dframe().copy()
+        install_ac_dipole_matrix(madx, deltaqx=-0.01, deltaqy=0.012)
+        twiss_after = madx.twiss().dframe().copy()
+
+        for acd_name in ("hacmap", "vacmap"):
+            assert acd_name in madx.elements
+            assert math.isclose(madx.elements[acd_name].at, 9846.0765, rel_tol=1e-2)
+
+        with pytest.raises(AssertionError):
+            assert_frame_equal(twiss_before, twiss_after)  # they should be different!
 
     def test_makethin_lhc(self, _matched_lhc_madx):
         """


### PR DESCRIPTION
- Hot fixes AC Dipole implementation that currently doesn't `use` the sequence after installation.
- Adds the possibility to choose the beam
- Adds the AC Dipole implementation as a matrix element for impact on TWISS functions

See https://journals.aps.org/prab/abstract/10.1103/PhysRevSTAB.11.084002 (part III).
